### PR TITLE
Update Migration.php

### DIFF
--- a/src/Migration.php
+++ b/src/Migration.php
@@ -395,9 +395,9 @@ class Migration
     }
 
     /**
-     * Run all scripts to down the database version from current version up to the specified version.
+     * Run all scripts to down the database version from current version down to 0 or the specified version.
      *
-     * @param int $upVersion
+     * @param int|null $upVersion
      * @param bool $force
      * @throws DatabaseDoesNotRegistered
      * @throws DatabaseIsIncompleteException
@@ -405,7 +405,7 @@ class Migration
      * @throws InvalidMigrationFile
      * @throws OldVersionSchemaException
      */
-    public function down(int $upVersion, bool $force = false): void
+    public function down(?int $upVersion = null, bool $force = false): void
     {
         $this->migrate($upVersion, -1, $force);
     }


### PR DESCRIPTION
Hi again, 

I noticed an issue in v5 of the migraiton cli. When running `vendor/bin/migrate down` without a version number, it used to go all the way to zero, now it just shows Fatal error

```
Fatal error: Uncaught TypeError: ByJG\DbMigration\Migration::down(): Argument #1 ($upVersion) must be of type int, null given, called in /builds/pMYRyEFjS/0/prosper/prosperlms/vendor/byjg/migration-cli/src/DownCommand.php on line 43 and defined in /builds/pMYRyEFjS/0/prosper/prosperlms/vendor/byjg/migration/src/Migration.php:408
Stack trace:
#0 /builds/pMYRyEFjS/0/prosper/prosperlms/vendor/byjg/migration-cli/src/DownCommand.php(43): ByJG\DbMigration\Migration->down(NULL, true)
#1 /builds/pMYRyEFjS/0/prosper/prosperlms/vendor/symfony/console/Command/Command.php(279): ByJG\DbMigration\Console\DownCommand->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#2 /builds/pMYRyEFjS/0/prosper/prosperlms/vendor/symfony/console/Application.php(1029): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#3 /builds/pMYRyEFjS/0/prosper/prosperlms/vendor/symfony/console/Application.php(316): Symfony\Component\Console\Application->doRunCommand(Object(ByJG\DbMigration\Console\DownCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#4 /builds/pMYRyEFjS/0/prosper/prosperlms/vendor/symfony/console/Application.php(167): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#5 /builds/pMYRyEFjS/0/prosper/prosperlms/vendor/byjg/migration-cli/scripts/migrate(23): Symfony\Component\Console\Application->run()
#6 /builds/pMYRyEFjS/0/prosper/prosperlms/vendor/bin/migrate(119): include('/builds/pMYRyEF...')
#7 {main}
  thrown in /builds/pMYRyEFjS/0/prosper/prosperlms/vendor/byjg/migration/src/Migration.php on line 408
```

Added null as an option for first parameter type so it doesn't crash :) 