### PR TITLE
Force read all table before drop the database.

### DIFF
--- a/src/Database/SqliteDatabase.php
+++ b/src/Database/SqliteDatabase.php
@@ -38,8 +38,10 @@ class SqliteDatabase extends AbstractDatabase
                     END;
         ");
 
-        foreach ($iterator as $row) {
-            $this->getDbDriver()->execute($row->get('command'));
+        $list = $iterator->toArray();
+
+        foreach ($list as $row) {
+            $this->getDbDriver()->execute($row['command']);
         }
     }
 


### PR DESCRIPTION
The SQL Driver lock the DB avoid to drop the database. The error was introduced after the preFetch = 0. When the preFetch was 50, the database will read and close the cursor. 