### PR TITLE
fix: explicity mark type as nullable to avoid PHP 8.4 Deprecation warning

### DIFF
--- a/src/Migration.php
+++ b/src/Migration.php
@@ -236,7 +236,7 @@ class Migration
      * @throws InvalidMigrationFile
      * @throws OldVersionSchemaException
      */
-    public function reset(int $upVersion = null): void
+    public function reset(?int $upVersion = null): void
     {
         $fileInfo = $this->getFileContent($this->getBaseSql());
 


### PR DESCRIPTION
This fixes the following deprecation warning in PHP 8.4

```
Deprecated: ByJG\DbMigration\Migration::reset(): Implicitly marking parameter $upVersion as nullable is deprecated, the explicit nullable type must be used instead in /****/vendor/byjg/migration/src/Migration.php on line 239
```


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
